### PR TITLE
fix: use safe temp files for rewrites

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -76,13 +76,33 @@ func (f *File) Read() string {
 // Write content to file atomically, by writing it to a temporary file first,
 // and then moving it to the destination, overwriting the original.
 func (f *File) Write(content string) {
-	tempName := filepath.Join(f.Dir(), RandomString(20))
-	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
+	tempFile, err := os.CreateTemp(f.Dir(), ".find-replace-*")
+	if err != nil {
 		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
+	}
+	tempName := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tempName)
+		}
+	}()
+
+	if err := tempFile.Chmod(f.Mode()); err != nil {
+		_ = tempFile.Close()
+		log.Fatalf("Unable to set permissions on temp file %v: %v", tempName, err)
+	}
+	if _, err := tempFile.WriteString(content); err != nil {
+		_ = tempFile.Close()
+		log.Fatalf("Error writing tempfile in %v: %v", f.Dir(), err)
+	}
+	if err := tempFile.Close(); err != nil {
+		log.Fatalf("Error closing tempfile %v: %v", tempName, err)
 	}
 
 	log.Printf("Rewriting %v", f.Path)
 	if err := os.Rename(tempName, f.Path); err != nil {
 		log.Fatalf("Unable to atomically move temp file %v to %v: %v", tempName, f.Path, err)
 	}
+	removeTemp = false
 }

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,78 @@
 package main
 
-import "testing"
+import (
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestNewFile(t *testing.T) {
+}
+
+func TestFileWriteDoesNotFollowPredictableTempSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on many Windows setups")
+	}
+
+	if os.Getenv("FIND_REPLACE_SYMLINK_HELPER") == "1" {
+		runFileWriteSymlinkScenario(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestFileWriteDoesNotFollowPredictableTempSymlink$")
+	cmd.Env = append(os.Environ(), "FIND_REPLACE_SYMLINK_HELPER=1", "GODEBUG=randseednop=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("File.Write followed a predictable temp-file symlink:\n%s", output)
+	}
+}
+
+func runFileWriteSymlinkScenario(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.txt")
+	victimPath := filepath.Join(dir, "victim.txt")
+
+	if err := os.WriteFile(targetPath, []byte("old contents"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%q): %v", targetPath, err)
+	}
+	if err := os.WriteFile(victimPath, []byte("victim contents"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%q): %v", victimPath, err)
+	}
+
+	rand.Seed(1)
+	predictableTempPath := filepath.Join(dir, RandomString(20))
+	rand.Seed(1)
+
+	if err := os.Symlink(victimPath, predictableTempPath); err != nil {
+		t.Fatalf("os.Symlink(%q, %q): %v", victimPath, predictableTempPath, err)
+	}
+
+	NewFile(targetPath).Write("new contents")
+
+	victimContents, err := os.ReadFile(victimPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", victimPath, err)
+	}
+	if string(victimContents) != "victim contents" {
+		t.Fatalf("victim file was modified via predictable temp symlink: %q", victimContents)
+	}
+
+	info, err := os.Lstat(targetPath)
+	if err != nil {
+		t.Fatalf("os.Lstat(%q): %v", targetPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("target path was replaced by a symlink")
+	}
+
+	targetContents, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", targetPath, err)
+	}
+	if string(targetContents) != "new contents" {
+		t.Fatalf("target contents = %q; want %q", targetContents, "new contents")
+	}
 }


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Replace predictable `RandomString` temp-file names in `File.Write` with `os.CreateTemp` in the destination directory.
- Keep the existing atomic rename behavior while applying the destination file mode to the temporary file.
- Clean up temporary files on write/chmod/close/rename failures.
- Add a regression test proving a predictable temp-file symlink is not followed during rewrites.

## Test plan
- `go test -run TestFileWriteDoesNotFollowPredictableTempSymlink`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./...`
- `git diff --check`

Fixes #3
