### PR TITLE
fix: add --version flag and skip orphan temp files

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -76,7 +76,7 @@ func (f *File) Read() string {
 // Write content to file atomically, by writing it to a temporary file first,
 // and then moving it to the destination, overwriting the original.
 func (f *File) Write(content string) {
-	tempName := filepath.Join(f.Dir(), RandomString(20))
+	tempName := filepath.Join(f.Dir(), tempFilePrefix+RandomString(20))
 	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
 		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
 	}

--- a/find_replace.go
+++ b/find_replace.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"flag"
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
@@ -10,6 +12,8 @@ import (
 	"sync"
 	"time"
 )
+
+const tempFilePrefix = ".find-replace-"
 
 // findReplace is a struct used to provide context to all find & replace
 // operations, including the strings to search for & replace.
@@ -31,12 +35,23 @@ func main() {
 	log.SetFlags(0)
 	rand.Seed(time.Now().UnixNano())
 
-	if len(os.Args) != 3 {
-		log.Fatal("Usage: find-replace FIND REPLACE")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	showVersionShort := flag.Bool("v", false, "print version and exit (shorthand)")
+	flag.Parse()
+
+	if *showVersion || *showVersionShort {
+		fmt.Printf("find-replace %s commit=%s go=%s built=%s os=%s arch=%s tainted=%s\n",
+			GitTag, GitCommit, GoVersion, BuildTimestamp, BuildOS, BuildArch, BuildTainted)
+		return
 	}
 
-	find := os.Args[1]
-	replace := os.Args[2]
+	args := flag.Args()
+	if len(args) != 2 {
+		log.Fatal("Usage: find-replace [-v|--version] FIND REPLACE")
+	}
+
+	find := args[0]
+	replace := args[1]
 
 	fr := findReplace{find: find, replace: replace}
 
@@ -84,6 +99,9 @@ func (fr *findReplace) HandleFile(f *File) {
 			return
 		}
 		fr.WalkDir(f)
+	} else if strings.HasPrefix(f.Base(), tempFilePrefix) {
+		// Skip orphan temp files left by interrupted rewrites
+		return
 	} else {
 		// Replace the contents of regular files
 		fr.ReplaceContents(f)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,11 @@
+package main
+
+var (
+	GitTag         = "(dev)"
+	GitCommit      = "(unknown)"
+	GoVersion      = "(unknown)"
+	BuildTimestamp = "(unknown)"
+	BuildOS        = "(unknown)"
+	BuildArch      = "(unknown)"
+	BuildTainted   = "(unknown)"
+)


### PR DESCRIPTION
## Summary
- Add `version.go` for ldflags-injected build metadata and `-v`/`--version`.
- Prefix rewrite temp files with `.find-replace-` and skip them on later runs.

Fixes #26
Fixes #21