### PR TITLE
fix: preserve file mtime after atomic rewrite

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -77,8 +77,12 @@ func (f *File) Read() string {
 // and then moving it to the destination, overwriting the original.
 func (f *File) Write(content string) {
 	tempName := filepath.Join(f.Dir(), RandomString(20))
+	modTime := f.Info().ModTime()
 	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
 		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
+	}
+	if err := os.Chtimes(tempName, modTime, modTime); err != nil {
+		log.Fatalf("Failed to preserve mtime on temp file %v: %v", tempName, err)
 	}
 
 	log.Printf("Rewriting %v", f.Path)

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,30 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+	"time"
+)
 
-func TestNewFile(t *testing.T) {
+func TestFileWritePreservesModTime(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/mtime.txt"
+	if err := os.WriteFile(path, []byte("before"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2019, 3, 14, 15, 9, 26, 0, time.UTC)
+	if err := os.Chtimes(path, want, want); err != nil {
+		t.Fatal(err)
+	}
+
+	f := NewFile(path)
+	f.Write("after")
+
+	got, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.ModTime().Equal(want) {
+		t.Fatalf("ModTime = %v, want %v", got.ModTime(), want)
+	}
 }


### PR DESCRIPTION
## Summary
- Call `os.Chtimes` on the temp file before `Rename` so modification time matches the original file
- Add regression test for mtime preservation

Fixes #23

## Test plan
- [x] `go test ./...`