### PR TITLE
feat: two-phase rename for path collision safety

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -2,13 +2,20 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
+)
+
+type operationScope int
+
+const (
+	scopeAll operationScope = iota
+	scopeContentOnly
+	scopeRenameOnly
 )
 
 // findReplace is a struct used to provide context to all find & replace
@@ -16,6 +23,9 @@ import (
 type findReplace struct {
 	find    string
 	replace string
+	scope   operationScope
+	renames []renamePlan
+	renameMu sync.Mutex
 }
 
 // main processes command line arguments, builds the context struct, and begins
@@ -26,19 +36,43 @@ type findReplace struct {
 // • dirName: the name of a directory, without a trailing separator
 // • baseName: the relative name of a file, without a directory
 // • path: the relative path to a specific file or directory, including both dirName and baseName
+func parseArgs(args []string) (findReplace, error) {
+	scope := scopeAll
+	i := 0
+	for i < len(args) && strings.HasPrefix(args[i], "-") {
+		switch args[i] {
+		case "--content-only":
+			if scope != scopeAll {
+				return findReplace{}, fmt.Errorf("cannot pass both --content-only and --rename-only")
+			}
+			scope = scopeContentOnly
+		case "--rename-only":
+			if scope != scopeAll {
+				return findReplace{}, fmt.Errorf("cannot pass both --content-only and --rename-only")
+			}
+			scope = scopeRenameOnly
+		default:
+			return findReplace{}, fmt.Errorf("unknown flag: %s", args[i])
+		}
+		i++
+	}
+
+	rest := args[i:]
+	if len(rest) != 2 {
+		return findReplace{}, fmt.Errorf("usage: find-replace [--content-only | --rename-only] FIND REPLACE")
+	}
+
+	return findReplace{find: rest[0], replace: rest[1], scope: scope}, nil
+}
+
 func main() {
 	// Remove date/time from logging output
 	log.SetFlags(0)
-	rand.Seed(time.Now().UnixNano())
 
-	if len(os.Args) != 3 {
-		log.Fatal("Usage: find-replace FIND REPLACE")
+	fr, err := parseArgs(os.Args[1:])
+	if err != nil {
+		log.Fatal(err)
 	}
-
-	find := os.Args[1]
-	replace := os.Args[2]
-
-	fr := findReplace{find: find, replace: replace}
 
 	// Recursively explore the hierarchy depth first, rewrite files as needed,
 	// and rename files last (after we don't have to revisit them).
@@ -46,7 +80,17 @@ func main() {
 	// alphabetically, breadth-first (and you'd be renaming files that you
 	// haven't explored yet).
 
-	fr.WalkDir(NewFile("."))
+	fr.Run(NewFile("."))
+}
+
+// Run walks from root and applies deferred renames when scope allows.
+func (fr *findReplace) Run(root *File) {
+	fr.WalkDir(root)
+	if fr.scope != scopeContentOnly {
+		if err := fr.applyRenames(); err != nil {
+			log.Fatal(err)
+		}
+	}
 }
 
 // Walks files in the directory given by dirName, which is a relative path to a
@@ -84,19 +128,23 @@ func (fr *findReplace) HandleFile(f *File) {
 			return
 		}
 		fr.WalkDir(f)
-	} else {
+	} else if fr.scope != scopeRenameOnly {
 		// Replace the contents of regular files
 		fr.ReplaceContents(f)
 	}
 
-	// Rename the file now that we're otherwise done with it
-	fr.RenameFile(f)
+	if fr.scope != scopeContentOnly {
+		newBaseName := strings.ReplaceAll(f.Base(), fr.find, fr.replace)
+		if f.Base() != newBaseName {
+			fr.queueRename(f.Path, filepath.Join(f.Dir(), newBaseName))
+		}
+	}
 }
 
 // RenameFile renames a file if the destination file name does not already
 // exist.
 func (fr *findReplace) RenameFile(f *File) {
-	newBaseName := strings.Replace(f.Base(), fr.find, fr.replace, -1)
+	newBaseName := strings.ReplaceAll(f.Base(), fr.find, fr.replace)
 	newPath := filepath.Join(f.Dir(), newBaseName)
 
 	if f.Base() != newBaseName {
@@ -118,7 +166,7 @@ func (fr *findReplace) ReplaceContents(f *File) {
 	// an empty string and will be skipped here.
 	content := f.Read()
 	if strings.Contains(content, fr.find) {
-		newContent := strings.Replace(content, fr.find, fr.replace, -1)
+		newContent := strings.ReplaceAll(content, fr.find, fr.replace)
 		f.Write(newContent)
 	}
 }

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,18 +18,19 @@ import (
 // If a baseName is not provided, a random file name is generated. Returns the
 // directory where the file was created, the file's directory entry, and the
 // actual name of the file.
-func newTestFile(path string, baseName string, content string) *File {
+func newTestFile(tb testing.TB, path string, baseName string, content string) *File {
+	tb.Helper()
 	f, err := os.CreateTemp(path, baseName)
 	if err != nil {
-		log.Fatal(err)
+		tb.Fatal(err)
 	}
 	if _, err := f.Write([]byte(content)); err != nil {
-		defer os.Remove(f.Name())
-		log.Fatal(err)
+		_ = os.Remove(f.Name())
+		tb.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
-		defer os.Remove(f.Name())
-		log.Fatal(err)
+		_ = os.Remove(f.Name())
+		tb.Fatal(err)
 	}
 
 	return NewFile(f.Name())
@@ -41,10 +41,11 @@ func newTestFile(path string, baseName string, content string) *File {
 // a baseName is not provided, a random file name is generated. Returns the
 // directory where the file was created, the file's directory entry, and the
 // actual name of the file.
-func newTestDir(path string, baseName string) *File {
+func newTestDir(tb testing.TB, path string, baseName string) *File {
+	tb.Helper()
 	dirPath, err := os.MkdirTemp(path, baseName)
 	if err != nil {
-		log.Fatal(err)
+		tb.Fatal(err)
 	}
 	return NewFile(dirPath)
 }
@@ -59,6 +60,7 @@ func expectedPathAfterRename(f *File, fr *findReplace) string {
 
 // assertFileExists ensures that the given File exists
 func assertFileExists(t *testing.T, f *File) {
+	t.Helper()
 	if _, err := os.Stat(f.Path); errors.Is(err, os.ErrNotExist) {
 		t.Errorf("test file %v does not exist", f.Path)
 	}
@@ -66,6 +68,7 @@ func assertFileExists(t *testing.T, f *File) {
 
 // assertFileNonexistent ensures that the File does not exist
 func assertFileNonexistent(t *testing.T, f *File) {
+	t.Helper()
 	if _, err := os.Stat(f.Path); !errors.Is(err, os.ErrNotExist) {
 		if err == nil {
 			t.Errorf("test file %v exists", f.Path)
@@ -76,6 +79,7 @@ func assertFileNonexistent(t *testing.T, f *File) {
 }
 
 func assertPathExistsAfterRename(t *testing.T, f *File, expectedPath string) *File {
+	t.Helper()
 	assertFileNonexistent(t, f)
 	newFile := NewFile(expectedPath)
 	assertFileExists(t, newFile)
@@ -95,54 +99,54 @@ func TestWalkDir(t *testing.T) {
 	find := "wh"
 	replace := "f"
 
-	d := newTestDir("", "*")
+	d := newTestDir(t, "", "*")
 	defer os.Remove(d.Path)
 
 	// d1: who/
-	d1 := newTestDir(d.Path, "who")
+	d1 := newTestDir(t, d.Path, "who")
 	defer os.Remove(d1.Path)
 
 	// d1d1: who/what/
-	d1d1 := newTestDir(d1.Path, "what")
+	d1d1 := newTestDir(t, d1.Path, "what")
 	defer os.Remove(d1d1.Path)
 
 	// d1d1f1: who/what/when (contains "where")
 	d1d1f1Contents := "where"
-	d1d1f1 := newTestFile(d1d1.Path, "when", d1d1f1Contents)
+	d1d1f1 := newTestFile(t, d1d1.Path, "when", d1d1f1Contents)
 	defer os.Remove(d1d1f1.Path)
 
 	// d2: what/
-	d2 := newTestDir(d.Path, "what")
+	d2 := newTestDir(t, d.Path, "what")
 	defer os.Remove(d2.Path)
 
 	// d2d1: what/when/
-	d2d1 := newTestDir(d2.Path, "when")
+	d2d1 := newTestDir(t, d2.Path, "when")
 	defer os.Remove(d2d1.Path)
 
 	// d2d1d1: what/when/where (directories with no files)
-	d2d1d1 := newTestDir(d2d1.Path, "where")
+	d2d1d1 := newTestDir(t, d2d1.Path, "where")
 	defer os.Remove(d2d1d1.Path)
 
 	// d3: when/
-	d3 := newTestDir(d.Path, "when")
+	d3 := newTestDir(t, d.Path, "when")
 	defer os.Remove(d3.Path)
 
 	// d3f1: when/where (contains "why")
 	d3f1Contents := "why"
-	d3f1 := newTestFile(d3.Path, "where", d3f1Contents)
+	d3f1 := newTestFile(t, d3.Path, "where", d3f1Contents)
 	defer os.Remove(d3f1.Path)
 
 	// d4: where/ (empty directory in base dir)
-	d4 := newTestDir(d.Path, "where")
+	d4 := newTestDir(t, d.Path, "where")
 	defer os.Remove(d4.Path)
 
 	// f1: why (file in base dir contains "wh")
 	f1Contents := "wh\nwh\nwh\n"
-	f1 := newTestFile(d.Path, "why", f1Contents)
+	f1 := newTestFile(t, d.Path, "why", f1Contents)
 	defer os.Remove(f1.Path)
 
 	fr := findReplace{find: find, replace: replace}
-	fr.WalkDir(d)
+	fr.Run(d)
 
 	// d1: who/ > fo/
 	d1ExpectedPath := expectedPathAfterRename(d1, &fr)
@@ -193,7 +197,7 @@ func TestHandleFileWithDir(t *testing.T) {
 	find := "ph"
 	replace := "f"
 
-	f := newTestDir("", initial)
+	f := newTestDir(t, "", initial)
 	defer os.Remove(f.Path)
 	expectedPath := filepath.Join(f.Dir(), strings.Replace(f.Base(), find, replace, -1))
 	defer os.Remove(expectedPath)
@@ -201,6 +205,9 @@ func TestHandleFileWithDir(t *testing.T) {
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
+	if err := fr.applyRenames(); err != nil {
+		t.Fatal(err)
+	}
 	assertPathExistsAfterRename(t, f, expectedPath)
 }
 
@@ -211,7 +218,7 @@ func TestHandleFileWithIgnoredDir(t *testing.T) {
 
 	dirPath := filepath.Join(os.TempDir(), initial)
 	if err := os.Mkdir(dirPath, 0700); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	f := NewFile(dirPath)
 	defer os.Remove(f.Path)
@@ -233,7 +240,7 @@ func TestHandleFileWithFile(t *testing.T) {
 	replace := "f"
 	want := "alfa"
 
-	f := newTestFile("", initial, initial)
+	f := newTestFile(t, "", initial, initial)
 	defer os.Remove(f.Path)
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
@@ -242,6 +249,9 @@ func TestHandleFileWithFile(t *testing.T) {
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
+	if err := fr.applyRenames(); err != nil {
+		t.Fatal(err)
+	}
 	assertPathExistsAfterRename(t, f, expectedPath)
 
 	got := NewFile(expectedPath).Read()
@@ -255,7 +265,7 @@ func TestRenameFile(t *testing.T) {
 	find := "ph"
 	replace := "f"
 
-	f := newTestFile("", initial, "")
+	f := newTestFile(t, "", initial, "")
 	defer os.Remove(f.Path)
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
@@ -270,6 +280,7 @@ func TestRenameFile(t *testing.T) {
 // assertNewContentsOfFile ensures that the contents of the file at the given
 // path exactly match the desired string.
 func assertNewContentsOfFile(t *testing.T, path string, initial string, find string, replace string, want string) {
+	t.Helper()
 	got := NewFile(path).Read()
 	if got != want {
 		t.Errorf("replace %v with %v in %v, but got %v; want %v", find, replace, initial, got, want)
@@ -282,7 +293,7 @@ func TestReplaceContents(t *testing.T) {
 	replace := "f"
 	want := "alfa"
 
-	f := newTestFile("", "*", initial)
+	f := newTestFile(t, "", "*", initial)
 	defer os.Remove(f.Path)
 	fr := findReplace{find: find, replace: replace}
 	fr.ReplaceContents(f)
@@ -295,7 +306,7 @@ func TestReplaceContentsEntireFile(t *testing.T) {
 	replace := "beta"
 	want := "beta"
 
-	f := newTestFile("", "*", initial)
+	f := newTestFile(t, "", "*", initial)
 	defer os.Remove(f.Path)
 	fr := findReplace{find: find, replace: replace}
 	fr.ReplaceContents(f)
@@ -308,7 +319,7 @@ func TestReplaceContentsMultipleMatchesSingleLine(t *testing.T) {
 	replace := "f"
 	want := "alfaalfa"
 
-	f := newTestFile("", "*", initial)
+	f := newTestFile(t, "", "*", initial)
 	defer os.Remove(f.Path)
 	fr := findReplace{find: find, replace: replace}
 	fr.ReplaceContents(f)
@@ -321,7 +332,7 @@ func TestReplaceContentsMultipleMatchesMultipleLines(t *testing.T) {
 	replace := "f"
 	want := "alfa\nalfa"
 
-	f := newTestFile("", "*", initial)
+	f := newTestFile(t, "", "*", initial)
 	defer os.Remove(f.Path)
 	fr := findReplace{find: find, replace: replace}
 	fr.ReplaceContents(f)
@@ -334,7 +345,7 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 	replace := "xyz"
 	want := "alpha"
 
-	f := newTestFile("", "*", initial)
+	f := newTestFile(t, "", "*", initial)
 	defer os.Remove(f.Path)
 	fr := findReplace{find: find, replace: replace}
 	fr.ReplaceContents(f)
@@ -342,7 +353,8 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 }
 
 func CloneRepoToTestDir(b *testing.B, repoUrl string) *File {
-	d := newTestDir("", "*")
+	b.Helper()
+	d := newTestDir(b, "", "*")
 	defer os.Remove(d.Path)
 
 	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", repoUrl, ".")
@@ -355,12 +367,89 @@ func CloneRepoToTestDir(b *testing.B, repoUrl string) *File {
 	return d
 }
 
+func TestParseArgsBothScopeFlags(t *testing.T) {
+	_, err := parseArgs([]string{"--content-only", "--rename-only", "a", "b"})
+	if err == nil {
+		t.Fatal("expected error when both scope flags are set")
+	}
+}
+
+func TestParseArgsDefaultScope(t *testing.T) {
+	fr, err := parseArgs([]string{"foo", "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fr.scope != scopeAll {
+		t.Errorf("scope = %v, want scopeAll", fr.scope)
+	}
+}
+
+func TestWalkDirContentOnly(t *testing.T) {
+	find := "foo"
+	replace := "bar"
+
+	root := newTestDir(t, "", "*")
+	defer os.Remove(root.Path)
+
+	named := newTestFile(t, root.Path, "foo_name.txt", "foo inside")
+	defer os.Remove(named.Path)
+
+	fr := findReplace{find: find, replace: replace, scope: scopeContentOnly}
+	fr.WalkDir(root)
+
+	assertFileExists(t, named)
+	assertNewContentsOfFile(t, named.Path, "foo inside", find, replace, "bar inside")
+}
+
+func TestWalkDirRenameOnly(t *testing.T) {
+	find := "foo"
+	replace := "bar"
+
+	root := newTestDir(t, "", "*")
+	defer os.Remove(root.Path)
+
+	named := newTestFile(t, root.Path, "foo_name.txt", "foo inside")
+	defer os.Remove(named.Path)
+
+	fr := findReplace{find: find, replace: replace, scope: scopeRenameOnly}
+	fr.Run(root)
+
+	expectedPath := expectedPathAfterRename(named, &fr)
+	assertPathExistsAfterRename(t, named, expectedPath)
+	assertNewContentsOfFile(t, expectedPath, "foo inside", find, replace, "foo inside")
+}
+
+func TestApplyRenamesSwap(t *testing.T) {
+	root := newTestDir(t, "", "*")
+	defer os.Remove(root.Path)
+
+	a := newTestFile(t, root.Path, "foo", "a")
+	defer os.Remove(a.Path)
+	b := newTestFile(t, root.Path, "bar", "b")
+	defer os.Remove(b.Path)
+
+	fr := findReplace{find: "foo", replace: "bar", scope: scopeRenameOnly}
+	fr.queueRename(a.Path, filepath.Join(root.Path, "bar"))
+	fr.queueRename(b.Path, filepath.Join(root.Path, "foo"))
+
+	if err := fr.applyRenames(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root.Path, "bar")); err != nil {
+		t.Fatalf("expected former foo file at bar: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root.Path, "foo")); err != nil {
+		t.Fatalf("expected former bar file at foo: %v", err)
+	}
+}
+
 func BenchmarkNova(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		d := CloneRepoToTestDir(b, "git@github.com:openstack/nova.git")
 		fr := findReplace{find: RandomString(2), replace: RandomString(2)}
 		b.StartTimer()
-		fr.WalkDir(d)
+		fr.Run(d)
 	}
 }

--- a/rename_plan.go
+++ b/rename_plan.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type renamePlan struct {
+	from string
+	to   string
+	temp string
+}
+
+func (fr *findReplace) queueRename(from, to string) {
+	fr.renameMu.Lock()
+	fr.renames = append(fr.renames, renamePlan{from: from, to: to})
+	fr.renameMu.Unlock()
+}
+
+func (fr *findReplace) applyRenames() error {
+	if len(fr.renames) == 0 {
+		return nil
+	}
+
+	active := make([]renamePlan, 0, len(fr.renames))
+	sources := make(map[string]bool, len(fr.renames))
+	targets := make(map[string]bool, len(fr.renames))
+	for _, r := range fr.renames {
+		if r.from == r.to {
+			continue
+		}
+		if targets[r.to] {
+			return fmt.Errorf("duplicate rename target %q", r.to)
+		}
+		active = append(active, r)
+		sources[r.from] = true
+		targets[r.to] = true
+	}
+
+	if len(active) == 0 {
+		return nil
+	}
+
+	for to := range targets {
+		if sources[to] {
+			continue
+		}
+		if _, err := os.Stat(to); err == nil {
+			return fmt.Errorf("refusing rename: %q already exists", to)
+		}
+	}
+
+	needsTwoPhase := false
+	for _, r := range active {
+		if sources[r.to] {
+			needsTwoPhase = true
+			break
+		}
+	}
+
+	sort.Slice(active, func(i, j int) bool {
+		return len(active[i].from) > len(active[j].from)
+	})
+
+	if needsTwoPhase {
+		return fr.applyRenamesTwoPhase(active)
+	}
+	return fr.applyRenamesDirect(active)
+}
+
+func (fr *findReplace) applyRenamesDirect(plans []renamePlan) error {
+	for _, r := range plans {
+		log.Printf("Renaming %v to %v", r.from, filepath.Base(r.to))
+		if err := os.Rename(r.from, r.to); err != nil {
+			return fmt.Errorf("rename %q -> %q: %w", r.from, r.to, err)
+		}
+	}
+	return nil
+}
+
+func (fr *findReplace) applyRenamesTwoPhase(plans []renamePlan) error {
+	rollback := func() {
+		for _, r := range plans {
+			if r.temp != "" {
+				_ = os.Remove(r.temp)
+			}
+		}
+	}
+
+	seq := 0
+	for i := range plans {
+		r := &plans[i]
+		r.temp = filepath.Join(filepath.Dir(r.from), fmt.Sprintf(".find-replace.tmp.%d.%d", os.Getpid(), seq))
+		seq++
+		log.Printf("Renaming %v to %v (phase 1)", r.from, filepath.Base(r.temp))
+		if err := os.Rename(r.from, r.temp); err != nil {
+			rollback()
+			return fmt.Errorf("phase 1 rename %q: %w", r.from, err)
+		}
+	}
+
+	phase2 := append([]renamePlan(nil), plans...)
+	sort.Slice(phase2, func(i, j int) bool {
+		return len(phase2[i].to) > len(phase2[j].to)
+	})
+
+	for _, r := range phase2 {
+		log.Printf("Renaming %v to %v (phase 2)", filepath.Base(r.temp), filepath.Base(r.to))
+		if err := os.Rename(r.temp, r.to); err != nil {
+			return fmt.Errorf("phase 2 rename %q -> %q: %w", r.temp, r.to, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Queue file/directory renames during the walk and apply them after content rewrites via `Run()`.
- Use direct deepest-first renames for normal trees; use two-phase temp renames when a target path is also a rename source (swap/cycle).
- Add `TestApplyRenamesSwap` for the `foo` ↔ `bar` swap case.

## Test plan

- [x] `go test ./...`
- [x] `TestWalkDir` / `TestApplyRenamesSwap`

Closes #35