### PR TITLE
fix: reject empty or no-op find/replace arguments

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
@@ -37,6 +38,9 @@ func main() {
 
 	find := os.Args[1]
 	replace := os.Args[2]
+	if err := validateFindReplace(find, replace); err != nil {
+		log.Fatal(err)
+	}
 
 	fr := findReplace{find: find, replace: replace}
 
@@ -47,6 +51,16 @@ func main() {
 	// haven't explored yet).
 
 	fr.WalkDir(NewFile("."))
+}
+
+func validateFindReplace(find, replace string) error {
+	if find == "" {
+		return fmt.Errorf("FIND must not be empty")
+	}
+	if find == replace {
+		return fmt.Errorf("FIND and REPLACE must be different")
+	}
+	return nil
 }
 
 // Walks files in the directory given by dirName, which is a relative path to a

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -341,6 +341,36 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
 
+
+func TestValidateFindReplace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		find    string
+		replace string
+		wantErr bool
+	}{
+		{name: "empty find", find: "", replace: "x", wantErr: true},
+		{name: "identical", find: "a", replace: "a", wantErr: true},
+		{name: "ok", find: "a", replace: "b", wantErr: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateFindReplace(tc.find, tc.replace)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func CloneRepoToTestDir(b *testing.B, repoUrl string) *File {
 	d := newTestDir("", "*")
 	defer os.Remove(d.Path)


### PR DESCRIPTION
## Summary

- Validate `FIND` is non-empty before walking the tree.
- Reject `FIND` equal to `REPLACE` (no-op that still exits 0 today).

## Test plan

- [x] `go test ./...`
- [x] `TestValidateFindReplace`

Closes #10