### PR TITLE
perf: avoid redundant Abs and Stat on directory walks

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -13,6 +13,7 @@ import (
 type File struct {
 	Path string
 	info os.FileInfo
+	isDir *bool
 }
 
 func NewFile(path string) *File {
@@ -23,12 +24,29 @@ func NewFile(path string) *File {
 	return &File{Path: absPath}
 }
 
+// NewChildFile joins name under an already-absolute parent without calling filepath.Abs again.
+func NewChildFile(parent *File, name string, entry os.DirEntry) *File {
+	child := &File{Path: filepath.Join(parent.Path, name)}
+	if entry != nil {
+		isDir := entry.IsDir()
+		child.isDir = &isDir
+	}
+	return child
+}
+
 func (f *File) Base() string {
 	return filepath.Base(f.Path)
 }
 
 func (f *File) Dir() string {
 	return filepath.Dir(f.Path)
+}
+
+func (f *File) IsDir() bool {
+	if f.isDir != nil {
+		return *f.isDir
+	}
+	return f.Info().IsDir()
 }
 
 func (f *File) Info() os.FileInfo {

--- a/find_replace.go
+++ b/find_replace.go
@@ -61,7 +61,8 @@ func (fr *findReplace) WalkDir(f *File) {
 	}
 
 	for _, file := range files {
-		childFile := NewFile(filepath.Join(f.Path, file.Name()))
+		entry := file
+		childFile := NewChildFile(f, entry.Name(), entry)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -78,7 +79,7 @@ func (fr *findReplace) WalkDir(f *File) {
 // will need to access it again.
 func (fr *findReplace) HandleFile(f *File) {
 	// If file is a directory, recurse immediately (depth-first).
-	if f.Info().IsDir() {
+	if f.IsDir() {
 		// Ignore certain directories
 		if f.Base() == ".git" {
 			return


### PR DESCRIPTION
## Summary

- Add `NewChildFile` to join paths under an absolute parent without calling `filepath.Abs` per entry (#15).
- Use `DirEntry.IsDir` for directory detection so walks do not `os.Stat` every directory entry (#13).

## Test plan

- [x] `go test ./...`

Closes #13 and #15