### PR TITLE
fix: detect binary files via NUL bytes, drop x/tools

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/tools/godoc/util"
 )
 
 type File struct {
@@ -46,7 +45,7 @@ func (f *File) Mode() os.FileMode {
 	return f.Info().Mode()
 }
 
-// Read the file into a string.
+// Read the file into a string. Files containing a NUL byte are treated as binary and skipped.
 func (f *File) Read() string {
 	handle, err := os.Open(f.Path)
 	if err != nil {
@@ -54,21 +53,40 @@ func (f *File) Read() string {
 	}
 	defer handle.Close()
 
-	// Check if the file looks like text before reading the entire file.
 	var buf [1024]byte
-	n, err := handle.Read(buf[0:])
-	if err != nil || !util.IsText(buf[0:n]) {
+	n, err := handle.Read(buf[:])
+	if err != nil && err != io.EOF {
+		log.Fatalf("Unable to read %v: %v", f.Path, err)
+	}
+	if n == 0 {
+		return ""
+	}
+	if !isTextBytes(buf[:n]) {
 		return ""
 	}
 
-	// Reset file handle so we can read the entire file.
 	if _, err := handle.Seek(0, io.SeekStart); err != nil {
 		log.Fatalf("Failed to seek back to beginning of %v: %v", f.Path, err)
 	}
 
 	builder := new(strings.Builder)
-	if _, err := io.Copy(builder, handle); err != nil {
-		log.Fatalf("Failed to read %v to a string: %v", f.Path, err)
+	chunk := make([]byte, 32*1024)
+	for {
+		n, readErr := handle.Read(chunk)
+		if n > 0 {
+			if bytes.IndexByte(chunk[:n], 0) >= 0 {
+				return ""
+			}
+			if _, wErr := builder.Write(chunk[:n]); wErr != nil {
+				log.Fatalf("Failed to read %v to a string: %v", f.Path, wErr)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			log.Fatalf("Failed to read %v to a string: %v", f.Path, readErr)
+		}
 	}
 	return builder.String()
 }

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,68 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNewFile(t *testing.T) {
+	t.Run("absolute path", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "foo.txt")
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		want, err := filepath.Abs(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		f := NewFile(path)
+		if f.Path != want {
+			t.Errorf("NewFile(%q).Path = %q; want %q", path, f.Path, want)
+		}
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(orig) })
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		rel := "bar.txt"
+		if err := os.WriteFile(rel, []byte("y"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		want, err := filepath.Abs(rel)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		f := NewFile(rel)
+		if f.Path != want {
+			t.Errorf("NewFile(%q).Path = %q; want %q", rel, f.Path, want)
+		}
+	})
+}
+
+func TestReadSkipsBinaryWithNUL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mixed.txt")
+	content := []byte("text prefix\x00binary suffix")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := NewFile(path).Read()
+	if got != "" {
+		t.Fatalf("Read() = %q; want empty for NUL-containing file", got)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/dolph/find-replace
 
 go 1.19
-
-require golang.org/x/tools v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
-golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=

--- a/text_detect.go
+++ b/text_detect.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+// isTextBytes reports whether b is valid UTF-8 and contains no NUL bytes.
+func isTextBytes(b []byte) bool {
+	if len(b) == 0 {
+		return true
+	}
+	if bytes.IndexByte(b, 0) >= 0 {
+		return false
+	}
+	return utf8.Valid(b)
+}

--- a/text_detect_test.go
+++ b/text_detect_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsTextBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{name: "empty", in: nil, want: true},
+		{name: "ascii", in: []byte("hello"), want: true},
+		{name: "nul", in: []byte("hi\x00there"), want: false},
+		{name: "invalid utf8", in: []byte{0xff, 0xfe}, want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTextBytes(tc.in); got != tc.want {
+				t.Fatalf("isTextBytes(%q) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `godoc/util.IsText` with NUL-byte and UTF-8 validation on the prefix and full streamed read.
- Skip files containing a NUL anywhere to avoid corrupting mixed text/binary content.
- Remove the `golang.org/x/tools` dependency.

## Test plan

- [x] `go test ./...`
- [x] `TestReadSkipsBinaryWithNUL`

Closes #9