### PR TITLE
fix: continue walk on per-file errors instead of log.Fatal

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package main
+
+import "log"
+
+func (fr *findReplace) noteError(format string, args ...interface{}) {
+	log.Printf(format, args...)
+	fr.hadErrors.Store(true)
+}

--- a/file_handling.go
+++ b/file_handling.go
@@ -11,8 +11,9 @@ import (
 )
 
 type File struct {
-	Path string
-	info os.FileInfo
+	Path    string
+	info    os.FileInfo
+	onError func(string, ...interface{})
 }
 
 func NewFile(path string) *File {
@@ -21,6 +22,14 @@ func NewFile(path string) *File {
 		log.Fatalf("Unable to resolve absolute path of %v: %v", path, err)
 	}
 	return &File{Path: absPath}
+}
+
+func (f *File) logError(format string, args ...interface{}) {
+	if f.onError != nil {
+		f.onError(format, args...)
+		return
+	}
+	log.Fatalf(format, args...)
 }
 
 func (f *File) Base() string {
@@ -35,7 +44,8 @@ func (f *File) Info() os.FileInfo {
 	if f.info == nil {
 		stat, err := os.Stat(f.Path)
 		if err != nil {
-			log.Fatalf("Failed to stat %v: %v", f.Path, err)
+			f.logError("Failed to stat %v: %v", f.Path, err)
+			return nil
 		}
 		f.info = stat
 	}
@@ -46,31 +56,32 @@ func (f *File) Mode() os.FileMode {
 	return f.Info().Mode()
 }
 
-// Read the file into a string.
-func (f *File) Read() string {
+// Read returns file contents and whether the read succeeded. Binary-looking files return "", true.
+func (f *File) Read() (string, bool) {
 	handle, err := os.Open(f.Path)
 	if err != nil {
-		log.Fatalf("Unable to open %v: %v", f.Path, err)
+		f.logError("Unable to open %v: %v", f.Path, err)
+		return "", false
 	}
 	defer handle.Close()
 
-	// Check if the file looks like text before reading the entire file.
 	var buf [1024]byte
 	n, err := handle.Read(buf[0:])
 	if err != nil || !util.IsText(buf[0:n]) {
-		return ""
+		return "", true
 	}
 
-	// Reset file handle so we can read the entire file.
 	if _, err := handle.Seek(0, io.SeekStart); err != nil {
-		log.Fatalf("Failed to seek back to beginning of %v: %v", f.Path, err)
+		f.logError("Failed to seek back to beginning of %v: %v", f.Path, err)
+		return "", false
 	}
 
 	builder := new(strings.Builder)
 	if _, err := io.Copy(builder, handle); err != nil {
-		log.Fatalf("Failed to read %v to a string: %v", f.Path, err)
+		f.logError("Failed to read %v to a string: %v", f.Path, err)
+		return "", false
 	}
-	return builder.String()
+	return builder.String(), true
 }
 
 // Write content to file atomically, by writing it to a temporary file first,
@@ -78,11 +89,12 @@ func (f *File) Read() string {
 func (f *File) Write(content string) {
 	tempName := filepath.Join(f.Dir(), RandomString(20))
 	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
-		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
+		f.logError("Error creating tempfile in %v: %v", f.Dir(), err)
+		return
 	}
 
 	log.Printf("Rewriting %v", f.Path)
 	if err := os.Rename(tempName, f.Path); err != nil {
-		log.Fatalf("Unable to atomically move temp file %v to %v: %v", tempName, f.Path, err)
+		f.logError("Unable to atomically move temp file %v to %v: %v", tempName, f.Path, err)
 	}
 }

--- a/find_replace.go
+++ b/find_replace.go
@@ -8,14 +8,16 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // findReplace is a struct used to provide context to all find & replace
 // operations, including the strings to search for & replace.
 type findReplace struct {
-	find    string
-	replace string
+	find      string
+	replace   string
+	hadErrors atomic.Bool
 }
 
 // main processes command line arguments, builds the context struct, and begins
@@ -46,7 +48,16 @@ func main() {
 	// alphabetically, breadth-first (and you'd be renaming files that you
 	// haven't explored yet).
 
-	fr.WalkDir(NewFile("."))
+	fr.WalkDir(fr.newFile("."))
+	if fr.hadErrors.Load() {
+		os.Exit(1)
+	}
+}
+
+func (fr *findReplace) newFile(path string) *File {
+	f := NewFile(path)
+	f.onError = fr.noteError
+	return f
 }
 
 // Walks files in the directory given by dirName, which is a relative path to a
@@ -57,16 +68,17 @@ func (fr *findReplace) WalkDir(f *File) {
 	// List the files in this directory.
 	files, err := os.ReadDir(f.Path)
 	if err != nil {
-		log.Fatalf("Unable to read directory: %v", err)
+		fr.noteError("Unable to read directory: %v", err)
+		return
 	}
 
-	for _, file := range files {
-		childFile := NewFile(filepath.Join(f.Path, file.Name()))
+	for _, entry := range files {
+		childFile := fr.newFile(filepath.Join(f.Path, entry.Name()))
 		wg.Add(1)
-		go func() {
+		go func(child *File) {
 			defer wg.Done()
-			fr.HandleFile(childFile)
-		}()
+			fr.HandleFile(child)
+		}(childFile)
 	}
 
 	wg.Wait() // for (potentially recursive) calls to return
@@ -77,8 +89,13 @@ func (fr *findReplace) WalkDir(f *File) {
 // complete, the file is renamed (if necessary) since no subsequent operations
 // will need to access it again.
 func (fr *findReplace) HandleFile(f *File) {
+	info := f.Info()
+	if info == nil {
+		return
+	}
+
 	// If file is a directory, recurse immediately (depth-first).
-	if f.Info().IsDir() {
+	if info.IsDir() {
 		// Ignore certain directories
 		if f.Base() == ".git" {
 			return
@@ -103,10 +120,10 @@ func (fr *findReplace) RenameFile(f *File) {
 		if _, err := os.Stat(newPath); errors.Is(err, os.ErrNotExist) {
 			log.Printf("Renaming %v to %v", f.Path, newBaseName)
 			if err := os.Rename(f.Path, newPath); err != nil {
-				log.Fatalf("Unable to rename %v to %v: %v", f.Path, newBaseName, err)
+				fr.noteError("Unable to rename %v to %v: %v", f.Path, newBaseName, err)
 			}
 		} else {
-			log.Fatalf("Refusing to rename %v to %v: %v already exists", f.Path, newBaseName, newPath)
+			fr.noteError("Refusing to rename %v to %v: %v already exists", f.Path, newBaseName, newPath)
 		}
 	}
 }
@@ -116,7 +133,10 @@ func (fr *findReplace) RenameFile(f *File) {
 func (fr *findReplace) ReplaceContents(f *File) {
 	// Find & replace the contents of text files. Binary-looking files return
 	// an empty string and will be skipped here.
-	content := f.Read()
+	content, ok := f.Read()
+	if !ok {
+		return
+	}
 	if strings.Contains(content, fr.find) {
 		newContent := strings.Replace(content, fr.find, fr.replace, -1)
 		f.Write(newContent)

--- a/find_replace_errors_test.go
+++ b/find_replace_errors_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWalkDirContinuesOnUnreadableDirectory(t *testing.T) {
+	root := newTestDir("", "*")
+	defer os.Remove(root.Path)
+
+	readable := newTestFile(root.Path, "ok.txt", "hello")
+	defer os.Remove(readable.Path)
+
+	noRead := filepath.Join(root.Path, "private")
+	if err := os.Mkdir(noRead, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(noRead)
+	if err := os.Chmod(noRead, 0o000); err != nil {
+		t.Skip("cannot chmod directory for permission test:", err)
+	}
+	defer func() { _ = os.Chmod(noRead, 0o700) }()
+
+	fr := findReplace{find: "hello", replace: "hi"}
+	fr.WalkDir(fr.newFile(root.Path))
+
+	if !fr.hadErrors.Load() {
+		t.Fatal("expected hadErrors after unreadable directory")
+	}
+
+	got, ok := NewFile(readable.Path).Read()
+	if !ok || got != "hi" {
+		t.Fatalf("readable file not rewritten: got %q ok=%v", got, ok)
+	}
+}

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -244,7 +244,10 @@ func TestHandleFileWithFile(t *testing.T) {
 	fr.HandleFile(f)
 	assertPathExistsAfterRename(t, f, expectedPath)
 
-	got := NewFile(expectedPath).Read()
+	got, ok := NewFile(expectedPath).Read()
+	if !ok {
+		t.Fatal("failed to read file")
+	}
 	if got != want {
 		t.Errorf("replace %v with %v in %v, but got %v; want %v", find, replace, initial, got, want)
 	}
@@ -270,7 +273,10 @@ func TestRenameFile(t *testing.T) {
 // assertNewContentsOfFile ensures that the contents of the file at the given
 // path exactly match the desired string.
 func assertNewContentsOfFile(t *testing.T, path string, initial string, find string, replace string, want string) {
-	got := NewFile(path).Read()
+	got, ok := NewFile(path).Read()
+	if !ok {
+		t.Fatalf("failed to read %v", path)
+	}
 	if got != want {
 		t.Errorf("replace %v with %v in %v, but got %v; want %v", find, replace, initial, got, want)
 	}


### PR DESCRIPTION
## Summary

- Add `noteError` / `hadErrors` and exit non-zero from `main` when any file-level error occurred.
- Log and continue when a directory cannot be read, or when stat/open/read/write/rename fails.
- Fix goroutine loop variable capture when spawning per-entry workers.

`NewFile` path resolution failures remain fatal (startup-level).

## Test plan

- [x] `go test ./...`
- [x] `TestWalkDirContinuesOnUnreadableDirectory`

Partial fix for #6