### PR TITLE
test: fix BenchmarkNova clone setup

### DIFF
--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -341,26 +341,30 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
 
-func CloneRepoToTestDir(b *testing.B, repoUrl string) *File {
-	d := newTestDir("", "*")
-	defer os.Remove(d.Path)
+func cloneRepoToBenchDir(b *testing.B, repoURL string) *File {
+	b.Helper()
+	d := newTestDir("", "bench")
+	b.Cleanup(func() { _ = os.RemoveAll(d.Path) })
 
-	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", repoUrl, ".")
+	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", repoURL, ".")
 	cmd.Dir = d.Path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		b.Errorf("failed to clone repo: %s", out)
+		b.Fatalf("failed to clone repo: %s", out)
 	}
 
 	return d
 }
 
 func BenchmarkNova(b *testing.B) {
+	const repoURL = "https://github.com/openstack/nova.git"
+
+	b.StopTimer()
+	d := cloneRepoToBenchDir(b, repoURL)
+	fr := findReplace{find: RandomString(2), replace: RandomString(2)}
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		b.StopTimer()
-		d := CloneRepoToTestDir(b, "git@github.com:openstack/nova.git")
-		fr := findReplace{find: RandomString(2), replace: RandomString(2)}
-		b.StartTimer()
 		fr.WalkDir(d)
 	}
 }


### PR DESCRIPTION
## Summary

- Clone `openstack/nova` once per benchmark run over **HTTPS** (no SSH keys required).
- Use `b.Cleanup` for temp dir teardown instead of a broken `defer` inside the helper.
- Measure only `WalkDir` in the timed loop.

Closes #16