### PR TITLE
perf: bound concurrent file work with a worker pool

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -16,6 +16,7 @@ import (
 type findReplace struct {
 	find    string
 	replace string
+	workers chan struct{}
 }
 
 // main processes command line arguments, builds the context struct, and begins
@@ -38,7 +39,11 @@ func main() {
 	find := os.Args[1]
 	replace := os.Args[2]
 
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{
+		find:    find,
+		replace: replace,
+		workers: make(chan struct{}, workerLimit()),
+	}
 
 	// Recursively explore the hierarchy depth first, rewrite files as needed,
 	// and rename files last (after we don't have to revisit them).
@@ -49,48 +54,63 @@ func main() {
 	fr.WalkDir(NewFile("."))
 }
 
+func (fr *findReplace) acquireWorker() {
+	fr.workers <- struct{}{}
+}
+
+func (fr *findReplace) releaseWorker() {
+	<-fr.workers
+}
+
+func (fr *findReplace) processFile(f *File) {
+	fr.acquireWorker()
+	defer fr.releaseWorker()
+	fr.ReplaceContents(f)
+	fr.RenameFile(f)
+}
+
 // Walks files in the directory given by dirName, which is a relative path to a
 // directory. Calls HandleFile for each file it finds, if it's not ignored.
 func (fr *findReplace) WalkDir(f *File) {
-	var wg sync.WaitGroup
-
-	// List the files in this directory.
 	files, err := os.ReadDir(f.Path)
 	if err != nil {
 		log.Fatalf("Unable to read directory: %v", err)
 	}
 
-	for _, file := range files {
-		childFile := NewFile(filepath.Join(f.Path, file.Name()))
+	var wg sync.WaitGroup
+	for _, entry := range files {
+		childFile := NewFile(filepath.Join(f.Path, entry.Name()))
+		if entry.IsDir() {
+			if childFile.Base() == ".git" {
+				continue
+			}
+			fr.WalkDir(childFile)
+			fr.RenameFile(childFile)
+			continue
+		}
+
 		wg.Add(1)
-		go func() {
+		go func(file *File) {
 			defer wg.Done()
-			fr.HandleFile(childFile)
-		}()
+			fr.processFile(file)
+		}(childFile)
 	}
 
-	wg.Wait() // for (potentially recursive) calls to return
+	wg.Wait()
 }
 
-// HandleFile immediately recurses depth-first into directories it finds,
-// otherwise calls ReplaceContents for regular files. When either operation is
-// complete, the file is renamed (if necessary) since no subsequent operations
-// will need to access it again.
+// HandleFile supports unit tests and mirrors the walk order: directories
+// synchronously, files through the bounded worker pool.
 func (fr *findReplace) HandleFile(f *File) {
-	// If file is a directory, recurse immediately (depth-first).
 	if f.Info().IsDir() {
-		// Ignore certain directories
 		if f.Base() == ".git" {
 			return
 		}
 		fr.WalkDir(f)
-	} else {
-		// Replace the contents of regular files
-		fr.ReplaceContents(f)
+		fr.RenameFile(f)
+		return
 	}
-
-	// Rename the file now that we're otherwise done with it
-	fr.RenameFile(f)
+	fr.processFile(f)
 }
 
 // RenameFile renames a file if the destination file name does not already

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -141,7 +141,7 @@ func TestWalkDir(t *testing.T) {
 	f1 := newTestFile(d.Path, "why", f1Contents)
 	defer os.Remove(f1.Path)
 
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.WalkDir(d)
 
 	// d1: who/ > fo/
@@ -197,7 +197,7 @@ func TestHandleFileWithDir(t *testing.T) {
 	defer os.Remove(f.Path)
 	expectedPath := filepath.Join(f.Dir(), strings.Replace(f.Base(), find, replace, -1))
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -220,7 +220,7 @@ func TestHandleFileWithIgnoredDir(t *testing.T) {
 	unexpectedName := strings.Replace(f.Base(), find, replace, -1)
 	unexpectedPath := filepath.Join(f.Dir(), unexpectedName)
 	defer os.Remove(unexpectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -238,7 +238,7 @@ func TestHandleFileWithFile(t *testing.T) {
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -260,7 +260,7 @@ func TestRenameFile(t *testing.T) {
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 
 	assertFileExists(t, f)
 	fr.RenameFile(f)
@@ -284,7 +284,7 @@ func TestReplaceContents(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -297,7 +297,7 @@ func TestReplaceContentsEntireFile(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -310,7 +310,7 @@ func TestReplaceContentsMultipleMatchesSingleLine(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -323,7 +323,7 @@ func TestReplaceContentsMultipleMatchesMultipleLines(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -336,7 +336,7 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := findReplace{find: find, replace: replace, workers: make(chan struct{}, workerLimit())}
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }

--- a/walk_pool.go
+++ b/walk_pool.go
@@ -1,0 +1,14 @@
+package main
+
+import "runtime"
+
+func workerLimit() int {
+	n := runtime.GOMAXPROCS(0) * 2
+	if n < 4 {
+		return 4
+	}
+	if n > 32 {
+		return 32
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

- Recurse into directories synchronously (depth-first, unchanged semantics).
- Process regular files through a bounded worker pool (4–32 workers from `GOMAXPROCS`).
- Avoid unbounded goroutine fan-out on large directories.

## Test plan

- [x] `go test ./...`

Closes #7