### PR TITLE
fix: stream file rewrites with bounded memory

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -46,7 +47,64 @@ func (f *File) Mode() os.FileMode {
 	return f.Info().Mode()
 }
 
-// Read the file into a string.
+func isSkippedTempName(name string) bool {
+	return strings.HasPrefix(name, ".find-replace.tmp.")
+}
+
+// StreamFindReplace rewrites the file in place when find occurs. Binary or
+// non-text files are skipped. Memory use is bounded by streamBufferSize.
+func (f *File) StreamFindReplace(find, replace string) {
+	if len(find) == 0 {
+		return
+	}
+
+	in, err := os.Open(f.Path)
+	if err != nil {
+		log.Fatalf("Unable to open %v: %v", f.Path, err)
+	}
+	defer in.Close()
+
+	var head [1024]byte
+	n, err := in.Read(head[:])
+	if err != nil && err != io.EOF {
+		log.Fatalf("Unable to read %v: %v", f.Path, err)
+	}
+	if n == 0 || !util.IsText(head[:n]) {
+		return
+	}
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		log.Fatalf("Failed to seek back to beginning of %v: %v", f.Path, err)
+	}
+
+	tempName := filepath.Join(f.Dir(), fmt.Sprintf(".find-replace.tmp.%d.%s", os.Getpid(), RandomString(8)))
+	out, err := os.OpenFile(tempName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+	if err != nil {
+		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
+	}
+
+	changed, err := streamReplace(in, out, []byte(find), []byte(replace))
+	closeErr := out.Close()
+	if err != nil {
+		_ = os.Remove(tempName)
+		log.Fatalf("Failed to rewrite %v: %v", f.Path, err)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tempName)
+		log.Fatalf("Failed to close tempfile for %v: %v", f.Path, closeErr)
+	}
+	if !changed {
+		_ = os.Remove(tempName)
+		return
+	}
+
+	log.Printf("Rewriting %v", f.Path)
+	if err := os.Rename(tempName, f.Path); err != nil {
+		_ = os.Remove(tempName)
+		log.Fatalf("Unable to atomically move temp file %v to %v: %v", tempName, f.Path, err)
+	}
+}
+
+// Read the file into a string (used by tests).
 func (f *File) Read() string {
 	handle, err := os.Open(f.Path)
 	if err != nil {
@@ -54,14 +112,12 @@ func (f *File) Read() string {
 	}
 	defer handle.Close()
 
-	// Check if the file looks like text before reading the entire file.
 	var buf [1024]byte
 	n, err := handle.Read(buf[0:])
 	if err != nil || !util.IsText(buf[0:n]) {
 		return ""
 	}
 
-	// Reset file handle so we can read the entire file.
 	if _, err := handle.Seek(0, io.SeekStart); err != nil {
 		log.Fatalf("Failed to seek back to beginning of %v: %v", f.Path, err)
 	}
@@ -73,10 +129,9 @@ func (f *File) Read() string {
 	return builder.String()
 }
 
-// Write content to file atomically, by writing it to a temporary file first,
-// and then moving it to the destination, overwriting the original.
+// Write content to file atomically (used by tests).
 func (f *File) Write(content string) {
-	tempName := filepath.Join(f.Dir(), RandomString(20))
+	tempName := filepath.Join(f.Dir(), fmt.Sprintf(".find-replace.tmp.%d.%s", os.Getpid(), RandomString(8)))
 	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
 		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
 	}

--- a/find_replace.go
+++ b/find_replace.go
@@ -61,6 +61,9 @@ func (fr *findReplace) WalkDir(f *File) {
 	}
 
 	for _, file := range files {
+		if isSkippedTempName(file.Name()) {
+			continue
+		}
 		childFile := NewFile(filepath.Join(f.Path, file.Name()))
 		wg.Add(1)
 		go func() {
@@ -114,11 +117,5 @@ func (fr *findReplace) RenameFile(f *File) {
 // Replaces the contents of the given file, using the find & replace values in
 // context.
 func (fr *findReplace) ReplaceContents(f *File) {
-	// Find & replace the contents of text files. Binary-looking files return
-	// an empty string and will be skipped here.
-	content := f.Read()
-	if strings.Contains(content, fr.find) {
-		newContent := strings.Replace(content, fr.find, fr.replace, -1)
-		f.Write(newContent)
-	}
+	f.StreamFindReplace(fr.find, fr.replace)
 }

--- a/stream_replace.go
+++ b/stream_replace.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"io"
+)
+
+const streamBufferSize = 256 * 1024
+
+// streamReplace copies from r to w, replacing every occurrence of find with replace.
+// It returns whether any replacement was made. Memory use is bounded by streamBufferSize
+// plus len(find) bytes of carry-over between reads.
+func streamReplace(r io.Reader, w io.Writer, find, replace []byte) (bool, error) {
+	if len(find) == 0 {
+		return false, nil
+	}
+
+	buf := make([]byte, streamBufferSize)
+	var pending []byte
+	var changed bool
+
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			data := append(pending, buf[:n]...)
+			isFinal := readErr == io.EOF
+			if !isFinal && len(data) < streamBufferSize {
+				pending = data
+				continue
+			}
+			out, rest, chunkChanged := replaceChunk(data, find, replace, isFinal)
+			if chunkChanged {
+				changed = true
+			}
+			if len(out) > 0 {
+				if _, err := w.Write(out); err != nil {
+					return changed, err
+				}
+			}
+			pending = rest
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return changed, readErr
+		}
+	}
+
+	if len(pending) > 0 {
+		out, _, chunkChanged := replaceChunk(pending, find, replace, true)
+		if chunkChanged {
+			changed = true
+		}
+		if len(out) > 0 {
+			if _, err := w.Write(out); err != nil {
+				return changed, err
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+func replaceChunk(data, find, replace []byte, final bool) (out []byte, rest []byte, changed bool) {
+	if len(data) == 0 {
+		return nil, nil, false
+	}
+
+	if final {
+		replaced := bytes.Replace(data, find, replace, -1)
+		return replaced, nil, !bytes.Equal(replaced, data)
+	}
+
+	overlap := len(find) - 1
+	if overlap >= len(data) {
+		return nil, append([]byte(nil), data...), false
+	}
+
+	split := len(data) - overlap
+	process := data[:split]
+	rest = append([]byte(nil), data[split:]...)
+
+	replaced := bytes.Replace(process, find, replace, -1)
+	return replaced, rest, !bytes.Equal(replaced, process)
+}

--- a/stream_replace_test.go
+++ b/stream_replace_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestStreamReplace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		find    string
+		replace string
+		want    string
+	}{
+		{name: "no match", input: "hello", find: "z", replace: "q", want: "hello"},
+		{name: "simple", input: "foo bar foo", find: "foo", replace: "baz", want: "baz bar baz"},
+		{name: "span boundary", input: "xxababc", find: "ab", replace: "X", want: "xxXXc"},
+		{name: "empty input", input: "", find: "a", replace: "b", want: ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			changed, err := streamReplace(strings.NewReader(tc.input), &out, []byte(tc.find), []byte(tc.replace))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.input != tc.want && !changed {
+				t.Fatal("expected changed=true")
+			}
+			if tc.input == tc.want && changed {
+				t.Fatal("expected changed=false")
+			}
+			if out.String() != tc.want {
+				t.Fatalf("got %q; want %q", out.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestStreamReplaceLargeWithSmallReads(t *testing.T) {
+	find := "needle"
+	replace := "pin"
+	input := strings.Repeat("hay", 1000) + find + strings.Repeat("stack", 1000)
+	want := strings.Replace(input, find, replace, 1)
+
+	var out bytes.Buffer
+	r := &smallReader{data: []byte(input), step: 3}
+	changed, err := streamReplace(r, &out, []byte(find), []byte(replace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected replacement")
+	}
+	if out.String() != want {
+		t.Fatalf("output length %d; want %d", out.Len(), len(want))
+	}
+}
+
+type smallReader struct {
+	data []byte
+	step int
+	off  int
+}
+
+func (r *smallReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := r.step
+	if n > len(p) {
+		n = len(p)
+	}
+	if n > len(r.data)-r.off {
+		n = len(r.data) - r.off
+	}
+	copy(p, r.data[r.off:r.off+n])
+	r.off += n
+	return n, nil
+}


### PR DESCRIPTION
## Summary

- Rewrite file contents via `StreamFindReplace` using a fixed-size read buffer (256 KiB) instead of loading entire files into memory.
- Skip writing when no replacements occur; use `.find-replace.tmp.<pid>.*` temp names and skip them on subsequent walks.
- Keep `Read`/`Write` for tests; production path uses streaming.

## Test plan

- [x] `go test ./...`
- [x] `TestStreamReplace` / `TestStreamReplaceLargeWithSmallReads`

Closes #8