### PR TITLE
fix: remove temp file when atomic rename fails

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -73,16 +74,26 @@ func (f *File) Read() string {
 	return builder.String()
 }
 
-// Write content to file atomically, by writing it to a temporary file first,
-// and then moving it to the destination, overwriting the original.
-func (f *File) Write(content string) {
+// writeContent writes bytes via a temp file in the same directory, then renames
+// over the target. The temp file is removed if rename fails.
+func (f *File) writeContent(content []byte) error {
 	tempName := filepath.Join(f.Dir(), RandomString(20))
-	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
-		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
+	if err := os.WriteFile(tempName, content, f.Mode()); err != nil {
+		return fmt.Errorf("error creating tempfile in %v: %w", f.Dir(), err)
 	}
 
 	log.Printf("Rewriting %v", f.Path)
 	if err := os.Rename(tempName, f.Path); err != nil {
-		log.Fatalf("Unable to atomically move temp file %v to %v: %v", tempName, f.Path, err)
+		_ = os.Remove(tempName)
+		return fmt.Errorf("unable to atomically move temp file %v to %v: %w", tempName, f.Path, err)
+	}
+	return nil
+}
+
+// Write content to file atomically, by writing it to a temporary file first,
+// and then moving it to the destination, overwriting the original.
+func (f *File) Write(content string) {
+	if err := f.writeContent([]byte(content)); err != nil {
+		log.Fatalf("%v", err)
 	}
 }

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,57 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestNewFile(t *testing.T) {
+func TestWriteRemovesTempOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(dest); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &File{Path: dest}
+	err := f.writeContent([]byte("new"))
+	if err == nil {
+		t.Fatal("expected rename to fail when dest is a directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "dest" {
+			t.Errorf("leftover temp file %q in %s", e.Name(), dir)
+		}
+	}
+}
+
+func TestWriteSucceedsForRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := NewFile(path)
+	if err := f.writeContent([]byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("file content = %q; want %q", got, "new")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #5. When `File.Write` successfully creates a temp file but `os.Rename` fails, the temp file is now removed before exiting instead of being left on disk next to the target.

## Changes

- Extract `writeContent` so rename failure can run cleanup without duplicating logic
- Add tests for successful write and for temp cleanup when rename fails (dest is a directory)

## Test plan

- [x] `go test ./...`