### PR TITLE
fix: skip rewriting files with special mode bits

### DIFF
--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,21 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-func TestNewFile(t *testing.T) {
+func TestHasSpecialFileModeBits(t *testing.T) {
+	if !hasSpecialFileModeBits(os.ModeSetuid | 0o755) {
+		t.Error("expected setuid bit to be detected")
+	}
+	if !hasSpecialFileModeBits(os.ModeSetgid | 0o755) {
+		t.Error("expected setgid bit to be detected")
+	}
+	if !hasSpecialFileModeBits(os.ModeSticky | 0o755) {
+		t.Error("expected sticky bit to be detected")
+	}
+	if hasSpecialFileModeBits(0o644) {
+		t.Error("expected plain mode to pass through")
+	}
 }

--- a/find_replace.go
+++ b/find_replace.go
@@ -114,6 +114,11 @@ func (fr *findReplace) RenameFile(f *File) {
 // Replaces the contents of the given file, using the find & replace values in
 // context.
 func (fr *findReplace) ReplaceContents(f *File) {
+	if hasSpecialFileModeBits(f.Mode()) {
+		log.Printf("Skipping rewrite of %v: setuid, setgid, or sticky bit set", f.Path)
+		return
+	}
+
 	// Find & replace the contents of text files. Binary-looking files return
 	// an empty string and will be skipped here.
 	content := f.Read()

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"runtime"
 	"errors"
 	"log"
 	"os"
@@ -362,5 +363,36 @@ func BenchmarkNova(b *testing.B) {
 		fr := findReplace{find: RandomString(2), replace: RandomString(2)}
 		b.StartTimer()
 		fr.WalkDir(d)
+	}
+}
+
+func TestReplaceContentsSkipsSetuidFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("special mode bits not applicable")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "setuid.txt")
+	if err := os.WriteFile(path, []byte("needle"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o4755); err != nil {
+		t.Fatal(err)
+	}
+
+	f := NewFile(path)
+	if !hasSpecialFileModeBits(f.Mode()) {
+		t.Skip("setuid bit not supported in this environment")
+	}
+
+	fr := findReplace{find: "needle", replace: "hay"}
+	fr.ReplaceContents(f)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "needle" {
+		t.Fatalf("content = %q; want unchanged %q", got, "needle")
 	}
 }

--- a/mode_bits.go
+++ b/mode_bits.go
@@ -1,0 +1,9 @@
+package main
+
+import "os"
+
+const specialFileModeBits = os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+
+func hasSpecialFileModeBits(mode os.FileMode) bool {
+	return mode&specialFileModeBits != 0
+}


### PR DESCRIPTION
## Summary

Fixes #18. Files with setuid, setgid, or sticky bits are no longer rewritten; the tool logs a skip message instead of risking silent permission changes.

## Test plan

- [x] `go test ./...`