### PR TITLE
perf: precompute find/replace as []byte once per run

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"log"
 	"math/rand"
@@ -13,9 +14,21 @@ import (
 
 // findReplace is a struct used to provide context to all find & replace
 // operations, including the strings to search for & replace.
+
+func newFindReplace(find, replace string) findReplace {
+	return findReplace{
+		find:     find,
+		replace:  replace,
+		findB:    []byte(find),
+		replaceB: []byte(replace),
+	}
+}
+
 type findReplace struct {
 	find    string
 	replace string
+	findB    []byte
+	replaceB []byte
 }
 
 // main processes command line arguments, builds the context struct, and begins
@@ -38,7 +51,7 @@ func main() {
 	find := os.Args[1]
 	replace := os.Args[2]
 
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 
 	// Recursively explore the hierarchy depth first, rewrite files as needed,
 	// and rename files last (after we don't have to revisit them).
@@ -117,8 +130,11 @@ func (fr *findReplace) ReplaceContents(f *File) {
 	// Find & replace the contents of text files. Binary-looking files return
 	// an empty string and will be skipped here.
 	content := f.Read()
-	if strings.Contains(content, fr.find) {
-		newContent := strings.Replace(content, fr.find, fr.replace, -1)
-		f.Write(newContent)
+	if content == "" {
+		return
+	}
+	if bytes.Contains([]byte(content), fr.findB) {
+		newContent := bytes.Replace([]byte(content), fr.findB, fr.replaceB, -1)
+		f.Write(string(newContent))
 	}
 }

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -141,7 +141,7 @@ func TestWalkDir(t *testing.T) {
 	f1 := newTestFile(d.Path, "why", f1Contents)
 	defer os.Remove(f1.Path)
 
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.WalkDir(d)
 
 	// d1: who/ > fo/
@@ -197,7 +197,7 @@ func TestHandleFileWithDir(t *testing.T) {
 	defer os.Remove(f.Path)
 	expectedPath := filepath.Join(f.Dir(), strings.Replace(f.Base(), find, replace, -1))
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -220,7 +220,7 @@ func TestHandleFileWithIgnoredDir(t *testing.T) {
 	unexpectedName := strings.Replace(f.Base(), find, replace, -1)
 	unexpectedPath := filepath.Join(f.Dir(), unexpectedName)
 	defer os.Remove(unexpectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -238,7 +238,7 @@ func TestHandleFileWithFile(t *testing.T) {
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 
 	assertFileExists(t, f)
 	fr.HandleFile(f)
@@ -260,7 +260,7 @@ func TestRenameFile(t *testing.T) {
 	expectedName := strings.Replace(f.Base(), find, replace, -1)
 	expectedPath := filepath.Join(f.Dir(), expectedName)
 	defer os.Remove(expectedPath)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 
 	assertFileExists(t, f)
 	fr.RenameFile(f)
@@ -284,7 +284,7 @@ func TestReplaceContents(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -297,7 +297,7 @@ func TestReplaceContentsEntireFile(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -310,7 +310,7 @@ func TestReplaceContentsMultipleMatchesSingleLine(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -323,7 +323,7 @@ func TestReplaceContentsMultipleMatchesMultipleLines(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -336,7 +336,7 @@ func TestReplaceContentsNoMatches(t *testing.T) {
 
 	f := newTestFile("", "*", initial)
 	defer os.Remove(f.Path)
-	fr := findReplace{find: find, replace: replace}
+	fr := newFindReplace(find, replace)
 	fr.ReplaceContents(f)
 	assertNewContentsOfFile(t, f.Path, initial, find, replace, want)
 }
@@ -359,7 +359,7 @@ func BenchmarkNova(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		d := CloneRepoToTestDir(b, "git@github.com:openstack/nova.git")
-		fr := findReplace{find: RandomString(2), replace: RandomString(2)}
+		fr := newFindReplace(RandomString(2), RandomString(2))
 		b.StartTimer()
 		fr.WalkDir(d)
 	}


### PR DESCRIPTION
## Summary

Fixes #22. FIND and REPLACE are converted to `[]byte` once when the walk context is built via `newFindReplace`, instead of per file.

## Test plan

- [x] `go test ./...`