### PR TITLE
fix: preserve file owner/group on atomic rewrite

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -80,6 +80,10 @@ func (f *File) Write(content string) {
 	if err := os.WriteFile(tempName, []byte(content), f.Mode()); err != nil {
 		log.Fatalf("Error creating tempfile in %v: %v", f.Dir(), err)
 	}
+	if err := chownTempFromInfo(tempName, f.Info()); err != nil {
+		_ = os.Remove(tempName)
+		log.Fatalf("Failed to preserve ownership of temp file %v: %v", tempName, err)
+	}
 
 	log.Printf("Rewriting %v", f.Path)
 	if err := os.Rename(tempName, f.Path); err != nil {

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,6 +1,52 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+)
 
-func TestNewFile(t *testing.T) {
+func TestWritePreservesOwnership(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ownership preservation not implemented on Windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStat, ok := before.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("syscall.Stat_t not available")
+	}
+
+	NewFile(path).Write("new")
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStat, ok := after.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("expected syscall.Stat_t after rewrite")
+	}
+	if afterStat.Uid != beforeStat.Uid || afterStat.Gid != beforeStat.Gid {
+		t.Fatalf("ownership changed: uid %d->%d gid %d->%d",
+			beforeStat.Uid, afterStat.Uid, beforeStat.Gid, afterStat.Gid)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("content = %q; want %q", got, "new")
+	}
 }

--- a/ownership_unix.go
+++ b/ownership_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func chownTempFromInfo(tempPath string, info os.FileInfo) error {
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	return os.Chown(tempPath, int(sys.Uid), int(sys.Gid))
+}

--- a/ownership_windows.go
+++ b/ownership_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func chownTempFromInfo(tempPath string, info os.FileInfo) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

Fixes #17. Before renaming the temp file over the target, `os.Chown` restores the original file's uid/gid on Unix so running as root does not leave rewritten files owned by root.

## Test plan

- [x] `go test ./...` (includes `TestWritePreservesOwnership` on Unix)