### PR TITLE
Gitignore .claude/ session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ find-replace
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Claude Code session state (worktrees, etc.)
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore`. The Claude Code CLI creates
`.claude/worktrees/` inside the project root when a subagent runs with
`isolation: "worktree"`. That directory is per-session, per-developer
state — not project state — so it should not be tracked.

Without this entry, every Claude Code session that spawns an isolated
subagent leaves `.claude/` untracked in the working tree, which trips
`git status` cleanliness checks and pre-commit hooks.

No code or behavior change.

## Test plan

- [x] `git status` after this commit shows a clean tree even with
      `.claude/` present.
- [x] No production code touched.

Label `release:skip` — no user-visible behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tep5t8h97Q9KKbpLMbUEJr)_