### PR TITLE
Modernize CodeQL and golangci-lint action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,8 +15,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          version: latest
+          go-version-file: go.mod
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.62.0


### PR DESCRIPTION
## Summary

The CodeQL and golangci-lint workflows were pinned to action versions GitHub has retired:

- `actions/checkout@v2` (Node 12-based, retired)
- `github/codeql-action/{init,autobuild,analyze}@v1` (v1 retired by GitHub)
- `golangci/golangci-lint-action@v2` (from 2021)

These jobs were either silently failing or running in degraded mode, producing a false static-analysis signal on every PR.

Changes:

- Bump `actions/checkout` to `@v6` in both workflows (matches the existing `ci.yml` convention).
- Bump `github/codeql-action/*` to `@v3` (current stable major).
- Bump `golangci/golangci-lint-action` to `@v6`.
- Pin `golangci-lint` to `v1.62.0`. `version: latest` picks up new linters on every run, which can break unrelated PRs; a fixed version is deterministic and bumped intentionally.
- Add `actions/setup-go@v6` to the lint workflow, reading the Go version from `go.mod` so the lint job exercises the same toolchain as the test job (Go 1.20 after #66).

## Test plan

- [x] `gofmt -l .` — no output
- [x] `go vet ./...` — no output
- [x] `go build ./...` — no output
- [x] `go test -race ./...` — PASS
- [ ] CI lint job runs to completion on this PR (will be visible after push)
- [ ] CodeQL job runs to completion on this PR

Closes #27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tep5t8h97Q9KKbpLMbUEJr)_