### PR TITLE
fix(build): use portable date and uname -m in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ go vet
 GIT_COMMIT="$(git rev-parse --short $(git rev-list -1 HEAD))"
 GIT_TAG="$(git tag --points-at HEAD)"
 GO_VERSION="$(go version | cut -d' ' -f3)"
-BUILD_DATE="$(date --utc)"
-BUILD_ARCH="$(arch)"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+BUILD_ARCH="$(uname -m)"
 if [ "$(git status -s | wc -l)" -eq "0" ]; then
     BUILD_TAINTED=false
 else


### PR DESCRIPTION
## Summary

Fixes #32. Replace GNU-only `date --utc` and `arch` with portable `date -u` and `uname -m`.

## Test plan

- [x] `bash -n build.sh`

Made with [Cursor](https://cursor.com)