### PR TITLE
feat: add version metadata and -v/--version flag

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -77,6 +77,11 @@ func run(args []string, stderr io.Writer) int {
 	// Remove date/time from logging output.
 	log.SetFlags(0)
 
+	if len(args) == 2 && (args[1] == "-v" || args[1] == "--version") {
+		fmt.Fprintln(stderr, versionString())
+		return 0
+	}
+
 	if len(args) != 3 {
 		fmt.Fprintln(stderr, "Usage: find-replace FIND REPLACE")
 		return 1

--- a/version.go
+++ b/version.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+// Build metadata injected by build.sh via -ldflags -X.
+var (
+	GitTag         string
+	GitCommit      string
+	GoVersion      string
+	BuildTimestamp string
+	BuildOS        string
+	BuildArch      string
+	BuildTainted   string
+)
+
+func versionString() string {
+	tag := GitTag
+	if tag == "" {
+		tag = "dev"
+	}
+	commit := GitCommit
+	if commit == "" {
+		commit = "unknown"
+	}
+	return fmt.Sprintf(
+		"find-replace %s (%s) go=%s built=%s os=%s arch=%s tainted=%s",
+		tag, commit, GoVersion, BuildTimestamp, BuildOS, BuildArch, BuildTainted,
+	)
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionString(t *testing.T) {
+	GitTag = "v1.2.3"
+	GitCommit = "abc1234"
+	GoVersion = "go1.22.0"
+	BuildTimestamp = "2026-01-01T00:00:00Z"
+	BuildOS = "linux"
+	BuildArch = "amd64"
+	BuildTainted = "false"
+
+	got := versionString()
+	for _, want := range []string{"v1.2.3", "abc1234", "go1.22.0", "linux", "amd64"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("versionString() = %q; want substring %q", got, want)
+		}
+	}
+}
+
+func TestRunVersionFlag(t *testing.T) {
+	code := run([]string{"find-replace", "--version"}, ioDiscard{t})
+	if code != 0 {
+		t.Fatalf("run --version exit = %d; want 0", code)
+	}
+}
+
+type ioDiscard struct{ t *testing.T }
+
+func (d ioDiscard) Write(p []byte) (int, error) {
+	if !strings.Contains(string(p), "find-replace") {
+		d.t.Fatalf("version output = %q; want find-replace", p)
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
## Summary

Fixes #26. Adds `version.go` for build.sh ldflags and supports `-v`/`--version`.

## Test plan

- [x] `go test ./...`

Made with [Cursor](https://cursor.com)