### PR TITLE
ci: add staticcheck and govulncheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,9 @@ jobs:
 
       - name: go test
         run: go test -race ./...
+
+      - uses: dominikh/staticcheck-action@v1
+        with:
+          version: latest
+
+      - uses: golang/govulncheck-action@v1


### PR DESCRIPTION
## Summary

Fixes #30. Adds staticcheck and govulncheck steps to the CI workflow after the existing vet/build/test jobs.

## Test plan

- [x] `go test ./...`

Made with [Cursor](https://cursor.com)