### PR TITLE
feat: add --content-only and --rename-only scope flags

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -17,6 +17,9 @@ type findReplace struct {
 	find    string
 	replace string
 
+	contentOnly bool
+	renameOnly  bool
+
 	// errs accumulates non-fatal errors that occurred during a walk. The
 	// walker logs each error at the point of failure (preserving the
 	// operator-visible UX) and appends it here so main can surface a
@@ -69,6 +72,34 @@ func main() {
 	os.Exit(run(os.Args, os.Stderr))
 }
 
+
+func parseRunArgs(args []string) (find, replace string, contentOnly, renameOnly bool, err error) {
+	if len(args) < 3 {
+		return "", "", false, false, fmt.Errorf("usage: find-replace [--content-only|--rename-only] FIND REPLACE")
+	}
+	i := 1
+	for i < len(args) {
+		switch args[i] {
+		case "--content-only":
+			contentOnly = true
+			i++
+		case "--rename-only":
+			renameOnly = true
+			i++
+		default:
+			goto done
+		}
+	}
+done:
+	if contentOnly && renameOnly {
+		return "", "", false, false, fmt.Errorf("cannot pass both --content-only and --rename-only")
+	}
+	if len(args)-i != 2 {
+		return "", "", false, false, fmt.Errorf("usage: find-replace [--content-only|--rename-only] FIND REPLACE")
+	}
+	return args[i], args[i+1], contentOnly, renameOnly, nil
+}
+
 // run is the testable body of main. It returns the process exit code: 0 on
 // clean success, 1 if argument parsing failed or any traversal error was
 // recorded. Output documented in the README (Renaming/Rewriting lines) still
@@ -77,12 +108,16 @@ func run(args []string, stderr io.Writer) int {
 	// Remove date/time from logging output.
 	log.SetFlags(0)
 
-	if len(args) != 3 {
-		fmt.Fprintln(stderr, "Usage: find-replace FIND REPLACE")
+	find, replace, contentOnly, renameOnly, err := parseRunArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
 		return 1
 	}
 
-	fr := findReplace{find: args[1], replace: args[2]}
+	fr := findReplace{
+		find: find, replace: replace,
+		contentOnly: contentOnly, renameOnly: renameOnly,
+	}
 
 	// Recursively explore the hierarchy depth first, rewrite files as needed,
 	// and rename files last (after we don't have to revisit them).
@@ -163,14 +198,16 @@ func (fr *findReplace) HandleFile(f *File) error {
 			return nil
 		}
 		fr.WalkDir(f)
-	} else {
-		// Replace the contents of regular files.
+	} else if !fr.renameOnly {
 		if err := fr.ReplaceContents(f); err != nil {
 			return err
 		}
 	}
 
-	// Rename the file now that we're otherwise done with it.
+	if fr.contentOnly {
+		return nil
+	}
+
 	return fr.RenameFile(f)
 }
 

--- a/scope_flags_test.go
+++ b/scope_flags_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRunArgs(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantFind    string
+		wantReplace string
+		contentOnly bool
+		renameOnly  bool
+		wantErr     bool
+	}{
+		{name: "default", args: []string{"find-replace", "a", "b"}, wantFind: "a", wantReplace: "b"},
+		{name: "content only", args: []string{"find-replace", "--content-only", "a", "b"}, wantFind: "a", wantReplace: "b", contentOnly: true},
+		{name: "rename only", args: []string{"find-replace", "--rename-only", "a", "b"}, wantFind: "a", wantReplace: "b", renameOnly: true},
+		{name: "both flags", args: []string{"find-replace", "--content-only", "--rename-only", "a", "b"}, wantErr: true},
+		{name: "missing args", args: []string{"find-replace", "--content-only"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			find, replace, contentOnly, renameOnly, err := parseRunArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if find != tc.wantFind || replace != tc.wantReplace || contentOnly != tc.contentOnly || renameOnly != tc.renameOnly {
+				t.Fatalf("parseRunArgs() = (%q,%q,%v,%v); want (%q,%q,%v,%v)",
+					find, replace, contentOnly, renameOnly, tc.wantFind, tc.wantReplace, tc.contentOnly, tc.renameOnly)
+			}
+		})
+	}
+}
+
+func TestContentOnlySkipsRename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "needle.txt")
+	if err := os.WriteFile(path, []byte("needle content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := newFileOrFatal(t, path)
+
+	fr := findReplace{find: "needle", replace: "hay", contentOnly: true}
+	if err := fr.HandleFile(f); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file was renamed; want %q kept: %v", path, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hay content" {
+		t.Fatalf("content = %q; want rewritten content", got)
+	}
+}
+
+func TestRenameOnlySkipsContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "needle.txt")
+	if err := os.WriteFile(path, []byte("needle content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := newFileOrFatal(t, path)
+
+	fr := findReplace{find: "needle", replace: "hay", renameOnly: true}
+	if err := fr.HandleFile(f); err != nil {
+		t.Fatal(err)
+	}
+	renamed := filepath.Join(dir, "hay.txt")
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("original file still exists; expected rename")
+	}
+	got, err := os.ReadFile(renamed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "needle content" {
+		t.Fatalf("content = %q; want unchanged", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #36. Adds mutually exclusive `--content-only` and `--rename-only` flags so operators can limit find-replace to content rewrites or path renames only.

## Test plan

- [x] `go test ./...`

Made with [Cursor](https://cursor.com)