### PR TITLE
chore: add SECURITY.md, CONTRIBUTING.md, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thanks for helping improve find-replace.
+
+## Development setup
+
+```bash
+git clone https://github.com/dolph/find-replace.git
+cd find-replace
+go test ./...
+go vet ./...
+```
+
+`./build.sh` runs vet, a release-style build, and tests. It works on Linux and macOS.
+
+## Pull requests
+
+- One logical change per PR; link the issue (`Fixes #N`).
+- Run `go test ./...` and `go vet ./...` before pushing.
+- Match existing style: minimal comments, straightforward Go.
+- PR titles use conventional prefixes when possible: `fix:`, `feat:`, `docs:`, `test:`, `chore:`.
+
+## Labels
+
+Maintainers use `release:*` labels on PRs that should appear in release notes. If your change is user-visible, mention the desired release note in the PR body.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for reporting vulnerabilities privately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues privately so we can fix them before public disclosure.
+
+1. Open a [GitHub Security Advisory](https://github.com/dolph/find-replace/security/advisories/new) (preferred), or email the maintainer via the contact on their GitHub profile.
+2. Include steps to reproduce, affected versions, and impact if known.
+3. Do not open a public issue for exploitable vulnerabilities.
+
+We aim to acknowledge reports within a few business days and will coordinate disclosure once a fix is available.
+
+## Supported Versions
+
+Security fixes are applied to the latest release on the default branch.


### PR DESCRIPTION
## Summary

Fixes #29. Adds contributor/security docs and weekly Dependabot updates for Go modules and GitHub Actions.

## Test plan

- [x] Docs-only change

Made with [Cursor](https://cursor.com)