### PR TITLE
chore: bump minimum Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dolph/find-replace
 
-go 1.20
+go 1.22
 
 require golang.org/x/tools v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
-golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=


### PR DESCRIPTION
Fixes #28

Made with [Cursor](https://cursor.com)