### PR TITLE
fix: reject empty or no-op find/replace arguments

### DIFF
--- a/find_replace.go
+++ b/find_replace.go
@@ -73,12 +73,28 @@ func main() {
 // clean success, 1 if argument parsing failed or any traversal error was
 // recorded. Output documented in the README (Renaming/Rewriting lines) still
 // goes to log.Default(); usage and aggregated error summaries go to stderr.
+
+func validateFindReplace(find, replace string) error {
+	if find == "" {
+		return fmt.Errorf("FIND must not be empty")
+	}
+	if find == replace {
+		return fmt.Errorf("FIND and REPLACE must be different")
+	}
+	return nil
+}
+
 func run(args []string, stderr io.Writer) int {
 	// Remove date/time from logging output.
 	log.SetFlags(0)
 
 	if len(args) != 3 {
 		fmt.Fprintln(stderr, "Usage: find-replace FIND REPLACE")
+		return 1
+	}
+
+	if err := validateFindReplace(args[1], args[2]); err != nil {
+		fmt.Fprintln(stderr, err)
 		return 1
 	}
 

--- a/find_replace_test.go
+++ b/find_replace_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -658,6 +659,29 @@ func withWorkingDir(t *testing.T, dir string) {
 		t.Fatalf("Chdir(%q): %v", dir, err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+
+func TestValidateFindReplace(t *testing.T) {
+	cases := []struct {
+		find, replace string
+		wantErr       bool
+	}{
+		{"", "b", true},
+		{"a", "a", true},
+		{"a", "b", false},
+	}
+	for _, tc := range cases {
+		if err := validateFindReplace(tc.find, tc.replace); (err != nil) != tc.wantErr {
+			t.Fatalf("validateFindReplace(%q,%q) err=%v; wantErr=%v", tc.find, tc.replace, err, tc.wantErr)
+		}
+	}
+}
+
+func TestRunRejectsEmptyFind(t *testing.T) {
+	if code := run([]string{"find-replace", "", "b"}, io.Discard); code == 0 {
+		t.Fatal("expected non-zero exit for empty FIND")
+	}
 }
 
 func CloneRepoToTestDir(b *testing.B, repoUrl string) *File {


### PR DESCRIPTION
Fixes #10

Made with [Cursor](https://cursor.com)