### PR TITLE
fix(build): use portable date and uname -m in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,12 @@ go vet
 GIT_COMMIT="$(git rev-parse --short $(git rev-list -1 HEAD))"
 GIT_TAG="$(git tag --points-at HEAD)"
 GO_VERSION="$(go version | cut -d' ' -f3)"
-BUILD_DATE="$(date --utc)"
-BUILD_ARCH="$(arch)"
+if date --utc >/dev/null 2>&1; then
+    BUILD_DATE="$(date --utc)"
+else
+    BUILD_DATE="$(date -u)"
+fi
+BUILD_ARCH="$(uname -m)"
 if [ "$(git status -s | wc -l)" -eq "0" ]; then
     BUILD_TAINTED=false
 else


### PR DESCRIPTION
## Summary
- Use `date -u` fallback when GNU `date --utc` is unavailable
- Use `uname -m` instead of GNU `arch` for portable architecture detection

## Test plan
- [x] `go test ./...`
- [ ] `./build.sh` succeeds on macOS

Fixes #32

Made with [Cursor](https://cursor.com)