### PR TITLE
ci: add staticcheck and govulncheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,9 @@ jobs:
 
       - name: go test
         run: go test -race ./...
+
+      - uses: dominikh/staticcheck-action@v1
+        with:
+          version: latest
+
+      - uses: golang/govulncheck-action@v1


### PR DESCRIPTION
## Summary
- Install and run `staticcheck` after `go vet`
- Install and run `govulncheck` in CI

## Test plan
- [x] `go test ./...`

Fixes #30

Made with [Cursor](https://cursor.com)