### PR TITLE
fix: preserve file mtime after atomic rewrite

### DIFF
--- a/file_handling.go
+++ b/file_handling.go
@@ -93,14 +93,19 @@ func (f *File) Read() (string, error) {
 // step after its creation fails (including the rename); on success the remove
 // is a no-op because the file has already been renamed away.
 func (f *File) Write(content string) error {
-	mode, err := f.Mode()
+	info, err := f.Info()
 	if err != nil {
 		return err
 	}
+	mode := info.Mode()
+	modTime := info.ModTime()
 
 	tempName := filepath.Join(f.Dir(), RandomString(20))
 	if err := os.WriteFile(tempName, []byte(content), mode); err != nil {
 		return fmt.Errorf("create tempfile in %v: %w", f.Dir(), err)
+	}
+	if err := os.Chtimes(tempName, modTime, modTime); err != nil {
+		return fmt.Errorf("preserve mtime on temp file %v: %w", tempName, err)
 	}
 	// Make sure the temp file is removed if the rename below fails. On
 	// success, the rename has already moved the file to f.Path so this is

--- a/file_handling_test.go
+++ b/file_handling_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestNewFile exercises NewFile's path-resolution behavior.
@@ -75,5 +77,33 @@ func TestNewFile(t *testing.T) {
 				t.Errorf("NewFile(%q).Path = %q; want an absolute path", tc.input, got.Path)
 			}
 		})
+	}
+}
+
+func TestFileWritePreservesModTime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mtime.txt")
+	if err := os.WriteFile(path, []byte("before"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2019, 3, 14, 15, 9, 26, 0, time.UTC)
+	if err := os.Chtimes(path, want, want); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := NewFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Write("after"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.ModTime().Equal(want) {
+		t.Fatalf("ModTime = %v; want %v", got.ModTime(), want)
 	}
 }


### PR DESCRIPTION
## Summary
- Call `os.Chtimes` on the temp file before rename to preserve the original modification time

## Test plan
- [x] `go test -run ModTime ./...`

Fixes #23

Made with [Cursor](https://cursor.com)